### PR TITLE
Bump imgui to v1.90.7 and fix pdb installation step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(CMakeOptions.cmake)
 # PROJECT
 ##################################################################################################################
 
-set(imgui_VERSION 1.88.0)
+set(imgui_VERSION 1.90.7)
 
 project(imgui
   VERSION ${imgui_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ project(imgui
   HOMEPAGE_URL "https://github.com/ocornut/imgui"
 )
 
+include(GNUInstallDirs)
+
 set(CMAKE_VERBOSE_MAKEFILE TRUE CACHE BOOL "" FORCE)
 
 # Note that for multi-config generators, we don't need to set CMAKE_BUILD_TYPE.
@@ -186,13 +188,15 @@ install(FILES ${FONTS_FILES}
 if(MSVC)
   if(IMGUI_STATIC_LIBRARY)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/$<TARGET_FILE_BASE_NAME:${PROJECT_NAME}>.pdb
-      DESTINATION lib
-      CONFIGURATIONS Debug OR RelWithDebInfo
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      COMPONENT lib
+      OPTIONAL
     )
   else()
     install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}>
-      DESTINATION bin
-      CONFIGURATIONS Debug OR RelWithDebInfo
+      DESTINATION ${CMAKE_INSTALL_BINDIR}
+      COMPONENT bin
+      OPTIONAL
     )
   endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CMake cross platform module for building [Dear ImGui](https://github.com/ocornut
 
 Clone the project:
 ```bash
-git clone --recursive https://github.com/giladreich/cmake-imgui
+git clone --recursive --shallow-submodules https://github.com/giladreich/cmake-imgui
 cd cmake-imgui
 ```
 


### PR DESCRIPTION
### Description

Hi @giladreich,

Note that whilst building the project with `/Z7` linker flag, the installation step failed with missing pdb. This is because it assumes the pdb files will always exists on `Debug` or `RelWithDebInfo` builds. Example command:
```sh
cmake .. -G "Visual Studio 17 2022" -A Win32 -DIMGUI_WITH_BACKEND=ON -DIMGUI_BACKEND_PLATFORM=WIN32 -DIMGUI_BACKEND_DX9=ON -DCMAKE_INSTALL_PREFIX=pkg -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT="$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>" -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
```

Setting it to `OPTIONAL` will only install the pdb files if they exists, which should work on all scenarios, even if one configures their Release build to generate symbols, which is not so common. I also improved it by using GNU standard installation dirs using the `GNUInstallDirs` install module.

Additionally I took the courtesy to update the imgui submodule.